### PR TITLE
docs: diffrentiate different type id

### DIFF
--- a/src/components/navigation/sidebars/toc/Table.tsx
+++ b/src/components/navigation/sidebars/toc/Table.tsx
@@ -49,7 +49,7 @@ export const Table: Component<{
               <li class="types-item props-item">
                 <a
                   class="type-anchor"
-                  href={`#${prop}`}
+                  href={`#prop-${prop}`}
                 >
                   <Tag />
                   {prop}
@@ -66,7 +66,7 @@ export const Table: Component<{
               <li class="types-item func-item">
                 <a
                   class="type-anchor"
-                  href={`#${func}`}
+                  href={`#func-${func}`}
                 >
                   <RoundBrackets />
                   {func}
@@ -83,7 +83,7 @@ export const Table: Component<{
               <li class="types-item signals-item">
                 <a
                   class="type-anchor"
-                  href={`#${signal}`}
+                  href={`#signal-${signal}`}
                 >
                   <PowerCord />
                   {signal}
@@ -100,7 +100,7 @@ export const Table: Component<{
               <li class="types-item vars-item">
                 <a
                   class="type-anchor"
-                  href={`#${variant}`}
+                  href={`#variant-${variant}`}
                 >
                   <FourDiamonds />
                   {variant}

--- a/src/components/type/Functions.astro
+++ b/src/components/type/Functions.astro
@@ -22,7 +22,7 @@ const { funcData } = Astro.props;
       let genericType:string|undefined;
       let genericTypeLink:string|undefined;
       return (
-        <li id={item.name} class="typedata-root typefunc-root">
+        <li id={ `func-${item.name}` } class="typedata-root typefunc-root">
           <TypeTitle
             typekind="func"
             typename={item.name}

--- a/src/components/type/Properties.astro
+++ b/src/components/type/Properties.astro
@@ -37,7 +37,7 @@ const { propsKeys, propsData } = Astro.props;
         genericTypeLink = getQMLTypeLink(propData.type.of)
       }
       return (
-        <li id={ item } class="typedata-root typeprop-root">
+        <li id={ `prop-${item}` } class="typedata-root typeprop-root">
           <TypeTitle
             typekind="prop"
             typename={item}

--- a/src/components/type/Signals.astro
+++ b/src/components/type/Signals.astro
@@ -19,7 +19,7 @@ const { signalKeys, signalsData } = Astro.props;
       let genericType:string|undefined;
       let genericTypeLink:string|undefined;
       return (
-        <li id={ item } class="typedata-root typesignal-root">
+        <li id={ `signal-${item}` } class="typedata-root typesignal-root">
           <TypeTitle
             typekind="signal"
             typename={item}

--- a/src/components/type/Variants.astro
+++ b/src/components/type/Variants.astro
@@ -19,7 +19,7 @@ const { variantKeys, variantsData } = Astro.props;
         ? variantData.params.map(param => param.name)
         : [];
       return (
-        <li id={ item } class="typedata-root typevariant-root">
+        <li id={ `variant-${item}` } class="typedata-root typevariant-root">
           <TypeTitle 
             typekind="variant"
             typename={item}


### PR DESCRIPTION
Add different prefix to different type id to prevent duplicate type id like [`FileView`'s `loaded`](https://quickshell.outfoxxed.me/docs/types/Quickshell.Io/FileView/#loaded).

Marking as draft since I cant get the site to build on my machine.