### PR TITLE
remove updated info about guix channel

### DIFF
--- a/src/guide/v0_1_0/install-setup.md
+++ b/src/guide/v0_1_0/install-setup.md
@@ -103,10 +103,6 @@ Add the following to your channel list:
   (branch "master"))
 ```
 
-However, since the package definition is located in the source repository, it cannot be used
-as a channel out of the box. You can clone the repository and use `guix shell -f quickshell.scm`
-to use the git version of the package.
-
 ### Manual build
 See [BUILD.md](https://git.outfoxxed.me/quickshell/quickshell/src/branch/master/BUILD.md)
 for build instructions and configurations.

--- a/src/guide/v0_2_0/install-setup.md
+++ b/src/guide/v0_2_0/install-setup.md
@@ -106,10 +106,6 @@ Add the following to your channel list:
   (branch "master"))
 ```
 
-However, since the package definition is located in the source repository, it cannot be used
-as a channel out of the box. You can clone the repository and use `guix shell -f quickshell.scm`
-to use the git version of the package.
-
 ### Manual build
 See [BUILD.md](https://git.outfoxxed.me/quickshell/quickshell/src/branch/master/BUILD.md)
 for build instructions and configurations.


### PR DESCRIPTION
Guix upstream now allows using in tree source code channel by default, part of change made by https://github.com/quickshell-mirror/quickshell-web/pull/11 is now irelevant.

Currenty it does not build cause of error in package specification, but [I made a PR](https://github.com/quickshell-mirror/quickshell/pull/389) and it doesn't matter in term of wording in docs.