### PR TITLE
fix(snippets): use regex to strip encoding from copied text

### DIFF
--- a/src/config/io/markdown.ts
+++ b/src/config/io/markdown.ts
@@ -166,7 +166,15 @@ const shikiCopyButton: ShikiTransformer = {
         role: "button",
         "aria-label": "Copy to clipboard",
         "alia-live": "polite",
-        "data-code": this.source,
+        "data-code": this.source.replace(
+          /TYPE99(?:M(?:QS|QT_qml)_\w+99N(\w+)99)?(?:V(\w+)99T(?:func|signal|prop)99)?TYPE/g,
+          (_full, name, mname) => {
+            if (name && mname) return `${name}.${mname}`;
+            if (name) return name;
+            if (mname) return mname;
+            return "";
+          }
+        ),
         onclick: `
                 navigator.clipboard.writeText(this.dataset.code);
                 this.classList.add('copied');


### PR DESCRIPTION
# Description

I used a regex to strip out the encoding from `this.source` right before it's assigned to the button so the copy functionality works correctly.

Also a warning, to be able to properly test this I had to delete the `.astro` folder in between changes since if I didn't do that then the copy functionality wouldn't update. But this only happens with the current `NOVERSION` broken links, when my fix from my other PR is applied, then the functionality is live-updated correctly: https://github.com/quickshell-mirror/quickshell-web/pull/20.

# Captures
## Old copied text
<img width="1265" height="751" alt="image" src="https://github.com/user-attachments/assets/e6881101-2f98-47ee-8812-05f0b21df714" />

## New copied text
<img width="1228" height="745" alt="image" src="https://github.com/user-attachments/assets/0bd74b61-a93b-43e4-b220-193a3fc019d8" />