### PR TITLE
Fix/invalid aria role

### DIFF
--- a/src/config/io/markdown.ts
+++ b/src/config/io/markdown.ts
@@ -165,7 +165,7 @@ const shikiCopyButton: ShikiTransformer = {
         class: "copy-button",
         role: "button",
         "aria-label": "Copy to clipboard",
-        "alia-live": "polite",
+        "aria-live": "polite",
         "data-code": this.source,
         onclick: `
                 navigator.clipboard.writeText(this.dataset.code);

--- a/src/config/io/markdown.ts
+++ b/src/config/io/markdown.ts
@@ -179,7 +179,7 @@ const shikiCopyButton: ShikiTransformer = {
           "svg",
           {
             class: "copy-icon",
-            role: "icon",
+            "aria-hidden": "true",
             xmlns: "http://www.w3.org/2000/svg",
             width: "1em",
             height: "1em",
@@ -196,7 +196,7 @@ const shikiCopyButton: ShikiTransformer = {
           "svg",
           {
             class: "check-icon",
-            role: "icon",
+            "aria-hidden": "true",
             xmlns: "http://www.w3.org/2000/svg",
             width: "1em",
             height: "1em",


### PR DESCRIPTION
# Description

## Invalid Aria Role
The aria role `role: "icon"` is not a valid one under [WAI-ARIA](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles) and it made Astro throw errors when it appeared:

<img width="741" height="248" alt="image" src="https://github.com/user-attachments/assets/4a9fab4e-d8b2-4d47-89fe-0a2929e103f4" />

Since the SVG is just decorative and since the button already handles accessibility with `"aria-label": "Copy to clipboard"` I just changed the `role: "icon"` to `"aria-hidden": "true"` so the SVGs are ignored.

## `aria-live` Typo
I also changed the `alia-live` typo to `aria-live`

# Captures
## Before
<img width="741" height="248" alt="image" src="https://github.com/user-attachments/assets/4a9fab4e-d8b2-4d47-89fe-0a2929e103f4" />

## After
<img width="740" height="200" alt="image" src="https://github.com/user-attachments/assets/ecc60736-3ea9-40a2-b11c-fb75dc412ae5" />
